### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -763,6 +763,59 @@ git commit -m "Add feature X
 - Updated CHANGELOG.md with new feature"
 ```
 
+### Release Workflow
+
+**REQUIRED**: When creating a new release, always follow this workflow:
+
+```bash
+# 1. Create a release branch from main
+git checkout -b release/X.Y.Z
+
+# 2. Update CHANGELOG.md
+#    - Move [Unreleased] changes to new version section with date
+#    - Update version links at bottom of file
+#    - Keep empty [Unreleased] section for future changes
+
+# 3. Update version in app/build.gradle.kts
+#    - Increment versionCode
+#    - Update versionName to match release version
+
+# 4. Run pre-commit checks
+./gradlew formatKotlin
+./gradlew test
+./gradlew lintDebug
+./gradlew assembleDebug
+
+# 5. Commit release changes on release branch
+git add CHANGELOG.md app/build.gradle.kts
+git commit -m "Release X.Y.Z
+
+- Updated CHANGELOG.md for version X.Y.Z
+- Bumped version to X.Y.Z (versionCode: N)"
+
+# 6. Create and push release tag (without 'v' prefix)
+git tag -a X.Y.Z -m "Release X.Y.Z"
+git push origin release/X.Y.Z
+git push origin X.Y.Z
+
+# 7. Merge release branch to main via Pull Request
+#    - Create PR from release/X.Y.Z to main
+#    - Review and merge the release PR
+#    - Delete release branch after merge
+
+# 8. Create GitHub Release
+#    - Use the tag X.Y.Z
+#    - Copy changelog entries as release notes
+#    - Attach APK/AAB artifacts if needed
+```
+
+**Why use a release branch?**
+- Keeps main branch stable during release preparation
+- Allows for last-minute fixes on the release branch without blocking main
+- Provides clear separation between development and release preparation
+- Enables easy rollback if issues are found during release testing
+- Follows gitflow-style branching model for releases
+
 ### Git Tagging Convention
 
 When creating release tags, always use the version number **without** the `v` prefix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-12-07
+
 ### Added
 - Metro DI multi-module support with `:core:di` module
   - Created `:core:di` module for centralized dependency injection infrastructure
@@ -293,5 +295,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unremembered state objects by wrapping `derivedStateOf` with `remember`
 - Fixed restricted API usage by avoiding direct `WindowLayoutInfo` constructor call
 
-[Unreleased]: https://github.com/hossain-khan/device-catalog-app/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/hossain-khan/device-catalog-app/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/hossain-khan/device-catalog-app/compare/1.1.0...1.2.0
+[1.1.0]: https://github.com/hossain-khan/device-catalog-app/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/hossain-khan/device-catalog-app/releases/tag/1.0.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
 
     defaultConfig {
         applicationId = "dev.hossain.devicecatalog"
-        versionCode = 2
-        versionName = "1.1.0"
+        versionCode = 3
+        versionName = "1.2.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.2.0

This PR merges the release branch `release/1.2.0` into `main` to finalize the 1.2.0 release.

### 📦 Release Information
- **Version**: 1.2.0
- **Version Code**: 3
- **Release Date**: December 7, 2025
- **Release Tag**: [1.2.0](https://github.com/hossain-khan/device-catalog-app/releases/tag/1.2.0)

### ✨ What's New in 1.2.0

#### Major Features Added
- **Metro DI Multi-Module Support** - Created `:core:di` module for centralized dependency injection with best practices from CatchUp
- **Device Statistics Explorer** - Interactive data visualization with 6 stat categories and animated charts
- **Device Comparison Tool** - Side-by-side comparison of 2-4 devices with visual highlighting
- **Quiz Hub** - Central hub for educational quizzes with multiple quiz types
- **Phone Codename Quiz** - Test knowledge of device codenames with manufacturer selection
- **Brand Challenge Quiz** - Learn about brand ownership and manufacturer relationships
- **Dream Phone Survey** - 8-question wizard to help users find their ideal device
- **GitHub Codespaces Support** - Dev container configuration for cloud-based development
- **APK Size Analysis** - Automated APK size tracking in pull requests using Diffuse

#### Documentation Updates
- Added comprehensive release workflow documentation in Copilot instructions
- Documented the requirement to create release branches before releases
- Added gitflow-style release process guidelines

### 🔄 Changed
- Dream Phone Finder is now accessible from Quiz Hub

### ✅ Pre-Release Checks Completed
- [x] `./gradlew formatKotlin` - Code formatting passed
- [x] `./gradlew test` - All tests passed
- [x] `./gradlew lintDebug` - Lint checks passed
- [x] `./gradlew assembleDebug` - Debug build successful
- [x] CHANGELOG.md updated with version 1.2.0
- [x] Version bumped to 1.2.0 (versionCode: 3)
- [x] Release tag created and pushed

### 📝 Changelog
See [CHANGELOG.md](https://github.com/hossain-khan/device-catalog-app/blob/release/1.2.0/CHANGELOG.md#120---2025-12-07) for detailed changes.

### 🎯 Post-Merge Actions
After merging this PR:
1. ✅ Release tag `1.2.0` is already created and pushed
2. Create GitHub Release using tag `1.2.0` with changelog notes
3. Attach APK/AAB artifacts to the GitHub Release
4. Delete the `release/1.2.0` branch

---

**Release Workflow**: This release follows the new gitflow-style release process documented in the Copilot instructions, where release preparation happens on a dedicated release branch to keep `main` stable.