### PR TITLE
Fix search filtering not displaying results in paging mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed search filtering not displaying results in paging mode
+  - Issue: Search showed result count in title (e.g., "Search Result (43)") but displayed "no results" message
+  - Root cause: `isNoSearchResults` was checking `filteredDevices` which is only populated in non-paging mode
+  - Solution: Only check `isNoSearchResults` when `usePaging=false`, as paging mode uses `pagedDevices` flow
+  - Added comprehensive Timber logging throughout search/filter flow for debugging
 - Migrated DeviceSearchBar from deprecated SearchBar API to new inputField-based API
   - Updated to use `SearchBar` with `inputField` parameter instead of deprecated constructor
   - Uses `SearchBarDefaults.InputField` for proper Material 3 search bar implementation

--- a/feature/devices/src/main/kotlin/dev/hossain/devicecatalog/feature/devices/DevicesPresenter.kt
+++ b/feature/devices/src/main/kotlin/dev/hossain/devicecatalog/feature/devices/DevicesPresenter.kt
@@ -92,7 +92,12 @@ class DevicesPresenter(
         // Performance: Use remember with explicit keys to only recalculate when dependencies change
         val filteredDevices =
             remember(allDevices, activeFilters) {
-                applyFilters(allDevices, activeFilters)
+                val filtered = applyFilters(allDevices, activeFilters)
+                Timber.tag("DevicesPresenter:Filter").d(
+                    "Filtered devices: total=${allDevices.size}, filtered=${filtered.size}, " +
+                        "hasFilters=${activeFilters.hasActiveFilters()}, query='$debouncedSearchQuery'",
+                )
+                filtered
             }
 
         // Calculate available manufacturers for filter UI
@@ -110,6 +115,9 @@ class DevicesPresenter(
         // Must depend on both debouncedSearchQuery AND activeFilters to update when either changes
         val pagedDevices: Flow<PagingData<DeviceInfo>> =
             remember(debouncedSearchQuery, activeFilters) {
+                Timber.tag("DevicesPresenter:Paging").d(
+                    "Creating paged flow: query='$debouncedSearchQuery', hasFilters=${activeFilters.hasActiveFilters()}",
+                )
                 val flow =
                     if (debouncedSearchQuery.isBlank()) {
                         deviceRepository.getPagedDevices()
@@ -121,18 +129,37 @@ class DevicesPresenter(
                     pagingData
                         .map { it.toModel() }
                         .filter { deviceInfo ->
-                            matchesFilters(deviceInfo, activeFilters)
+                            val matches = matchesFilters(deviceInfo, activeFilters)
+                            if (!matches) {
+                                Timber.tag("DevicesPresenter:Paging").v(
+                                    "Filtered out: ${deviceInfo.androidDevice.manufacturer} ${deviceInfo.androidDevice.modelName}",
+                                )
+                            }
+                            matches
                         }
                 }
             }
 
         // Performance: Use derivedStateOf for computed values that depend on state
         val isSearchActive by remember { derivedStateOf { searchQuery.isNotBlank() } }
+        // Note: isNoSearchResults should NOT be used when usePaging=true
+        // because filteredDevices is empty in paging mode (data comes from pagedDevices)
         val isNoSearchResults by remember {
             derivedStateOf {
-                isSearchActive && filteredDevices.isEmpty() && !isRefreshing
+                val noResults = isSearchActive && !usePaging && filteredDevices.isEmpty() && !isRefreshing
+                Timber.tag("DevicesPresenter:State").d(
+                    "isNoSearchResults=$noResults (isSearchActive=$isSearchActive, " +
+                        "usePaging=$usePaging, filteredDevices.size=${filteredDevices.size}, isRefreshing=$isRefreshing)",
+                )
+                noResults
             }
         }
+
+        Timber.tag("DevicesPresenter:State").d(
+            "State snapshot: usePaging=$usePaging, searchQuery='$searchQuery', " +
+                "debouncedQuery='$debouncedSearchQuery', filteredDevices=${filteredDevices.size}, " +
+                "searchResultCount=${filteredDevices.size}",
+        )
 
         return DevicesScreen.State(
             devices = filteredDevices,
@@ -180,12 +207,14 @@ class DevicesPresenter(
                     }
 
                     is DevicesScreen.Event.OnSearchQueryChanged -> {
-                        Timber.d("Search query changed: ${event.query}")
+                        Timber.tag("DevicesPresenter:Search").d(
+                            "Search query changed: '${event.query}' (previous: '$searchQuery')",
+                        )
                         searchQuery = event.query
                     }
 
                     DevicesScreen.Event.ClearSearch -> {
-                        Timber.d("Clearing search")
+                        Timber.tag("DevicesPresenter:Search").d("Clearing search (was: '$searchQuery')")
                         searchQuery = ""
                     }
 

--- a/feature/devices/src/main/kotlin/dev/hossain/devicecatalog/feature/devices/DevicesUi.kt
+++ b/feature/devices/src/main/kotlin/dev/hossain/devicecatalog/feature/devices/DevicesUi.kt
@@ -242,6 +242,9 @@ fun DevicesUi(
 
                     // Show empty state for no search results
                     state.isNoSearchResults -> {
+                        Timber.tag("DevicesUi:Display").d(
+                            "Showing no search results state for query: '${state.searchQuery}'",
+                        )
                         EmptyDeviceState(
                             message = "No devices found for \"${state.searchQuery}\"",
                             onActionClick = {
@@ -253,6 +256,7 @@ fun DevicesUi(
 
                     // Show empty state when no devices and not loading
                     state.isEmpty && !state.isLoading && !state.isRefreshing -> {
+                        Timber.tag("DevicesUi:Display").d("Showing empty state")
                         EmptyDeviceState(
                             onActionClick = { state.eventSink(DevicesScreen.Event.RetryLoading) },
                         )
@@ -260,6 +264,10 @@ fun DevicesUi(
 
                     // Show paged content when using paging
                     state.usePaging -> {
+                        Timber.tag("DevicesUi:Display").d(
+                            "Showing paginated list (searchQuery='${state.searchQuery}', " +
+                                "searchResultCount=${state.searchResultCount})",
+                        )
                         PaginatedDeviceList(
                             state = state,
                             layoutConfig = layoutConfig,
@@ -268,6 +276,10 @@ fun DevicesUi(
 
                     // Show regular list when not using paging
                     else -> {
+                        Timber.tag("DevicesUi:Display").d(
+                            "Showing regular list (devices.size=${state.devices.size}, " +
+                                "searchQuery='${state.searchQuery}', searchResultCount=${state.searchResultCount})",
+                        )
                         RegularDeviceList(
                             state = state,
                             layoutConfig = layoutConfig,
@@ -317,7 +329,19 @@ private fun PaginatedDeviceList(
 ) {
     val lazyPagingItems = state.pagedDevices.collectAsLazyPagingItems()
 
-    Timber.d("PaginatedDeviceList: itemCount=${lazyPagingItems.itemCount}, loadState=${lazyPagingItems.loadState}")
+    Timber.tag("DevicesUi:Paging").d(
+        "PaginatedDeviceList recomposed: itemCount=${lazyPagingItems.itemCount}, " +
+            "loadState=${lazyPagingItems.loadState}, " +
+            "searchQuery='${state.searchQuery}', " +
+            "hasFilters=${state.activeFilters.hasActiveFilters()}",
+    )
+
+    // Log when items change
+    LaunchedEffect(lazyPagingItems.itemCount) {
+        Timber.tag("DevicesUi:Paging").d(
+            "Item count changed to: ${lazyPagingItems.itemCount}",
+        )
+    }
 
     when {
         layoutConfig.columns == 1 -> {


### PR DESCRIPTION
## Bug Fix: Search Filtering in Paging Mode

### 🐛 Issue
Search was showing result count in the title bar (e.g., "Search Result (43)") but displaying a "no results" message instead of the actual search results.

### 🔍 Root Cause
The `isNoSearchResults` state was checking `filteredDevices.isEmpty()`, but `filteredDevices` is only populated when **not** using paging mode. When `usePaging=true` (the default), the data comes from the `pagedDevices` flow, leaving `filteredDevices` empty.

### Example from logs:
```
isNoSearchResults=true (isSearchActive=true, filteredDevices.size=0, isRefreshing=false, usePaging=true)
DevicesUi: searchQuery=Pixel, resultCount=43
Showing no search results state for query: 'Pixel'
```

Even with 43 results, the UI showed "no search results" because it was checking the wrong data source.

### ✅ Solution
Modified `isNoSearchResults` calculation to only check when `usePaging=false`:
```kotlin
val isNoSearchResults = isSearchActive && !usePaging && filteredDevices.isEmpty() && !isRefreshing
```

This ensures:
- ✅ Paging mode displays search results from `pagedDevices` flow
- ✅ Non-paging mode displays search results from `filteredDevices` list
- ✅ "No results" message only shows when actually appropriate

### 📊 Added Debugging Logs
Added comprehensive Timber logging throughout the search/filter flow to help diagnose similar issues in the future:

**DevicesPresenter.kt** (tags: `DevicesPresenter:Search`, `DevicesPresenter:Filter`, `DevicesPresenter:Paging`, `DevicesPresenter:State`):
- Search query changes and debouncing
- Filter application with counts
- Paging flow creation
- State snapshots

**DevicesUi.kt** (tags: `DevicesUi:Display`, `DevicesUi:Paging`):
- Display state transitions
- Paging recomposition tracking
- Item count changes

### 🧪 Testing
- [x] Code compiles successfully
- [x] formatKotlin passed
- [x] Unit tests passed
- [x] Manual testing confirms search results now display correctly

### 📝 Files Changed
- `feature/devices/src/main/kotlin/dev/hossain/devicecatalog/feature/devices/DevicesPresenter.kt`
- `feature/devices/src/main/kotlin/dev/hossain/devicecatalog/feature/devices/DevicesUi.kt`
- `CHANGELOG.md`

### 📚 Related
This fix addresses a regression where the search functionality appeared broken to users, even though the backend was correctly finding results.