### PR TITLE
Revert "Clear stale data in Stats Explorer during category transitions"

### DIFF
--- a/feature/statsexplorer/src/main/kotlin/dev/hossain/devicecatalog/feature/statsexplorer/StatsExplorerPresenter.kt
+++ b/feature/statsexplorer/src/main/kotlin/dev/hossain/devicecatalog/feature/statsexplorer/StatsExplorerPresenter.kt
@@ -33,8 +33,6 @@ class StatsExplorerPresenter
                 initialValue = null,
                 key1 = selectedCategory,
             ) {
-                // Reset to null immediately when category changes to clear old data
-                value = null
                 Timber.d("Loading stats for category: $selectedCategory")
                 try {
                     when (selectedCategory) {

--- a/feature/statsexplorer/src/main/kotlin/dev/hossain/devicecatalog/feature/statsexplorer/StatsExplorerUi.kt
+++ b/feature/statsexplorer/src/main/kotlin/dev/hossain/devicecatalog/feature/statsexplorer/StatsExplorerUi.kt
@@ -52,8 +52,7 @@ fun StatsExplorerUi(
             onRefresh = { state.eventSink(StatsExplorerScreen.Event.Refresh) },
             modifier = Modifier.padding(innerPadding),
         ) {
-            if (state.statData == null) {
-                // Show loading indicator when data is null (initial load or category change)
+            if (state.isLoading && state.statData == null) {
                 LoadingIndicator()
             } else {
                 StatsExplorerContent(


### PR DESCRIPTION
Makes full UI refresh on each tap. Which is even more worse.

Reverts hossain-khan/device-catalog-app#153