### PR TITLE
Upgrade AGP to 9.3.0 and Gradle Wrapper to 9.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ androidxPaging = "3.3.6"
 
 # https://developer.android.com/build/releases/gradle-plugin
 # https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility
-agp = "9.1.0"
+agp = "9.3.0"
 circuit = "0.36.1"
 
 # Coil - Image loading library for Android backed by Kotlin Coroutines

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgraded **Android Gradle Plugin (AGP)** to `9.3.0`.
- Upgraded **Gradle Wrapper** to `9.5.0`.

## Verification
- `./gradlew help` & `./gradlew build --dry-run` succeeded.
- `./gradlew assembleDebug` succeeded with 0 errors.
- `./gradlew test` passed 100% cleanly.